### PR TITLE
bug(#107): clear frames after `map`

### DIFF
--- a/src/main/rules/101-invokedynamic-to-lambda.phr
+++ b/src/main/rules/101-invokedynamic-to-lambda.phr
@@ -37,7 +37,7 @@ pattern: |
           ⟧,
           𝜏13 ↦ ⟦
             φ ↦ Φ.jeo.handle,
-            𝜏14 ↦ 6,
+            𝜏14 ↦ 𝑒-target-handle,
             𝜏15 ↦ 𝑒-target-class,
             𝜏16 ↦ 𝑒-target-method,
             𝜏17 ↦ 𝑒-target-signature,
@@ -86,6 +86,7 @@ result: |
           method ↦ 𝑒-method,
           interface ↦ 𝑒-interface,
           lambda-signature ↦ 𝑒-lambda-signature,
+          target-handle ↦ 𝑒-target-handle,
           target-class ↦ 𝑒-target-class,
           target-method ↦ 𝑒-target-method,
           target-signature ↦ 𝑒-target-signature,

--- a/src/main/rules/101-invokedynamic-to-lambda.phr
+++ b/src/main/rules/101-invokedynamic-to-lambda.phr
@@ -10,7 +10,7 @@ pattern: |
     access ↦ 𝑒-class-access,
     supername ↦ 𝑒-class-supername,
     interfaces ↦ 𝑒-class-interfaces,
-    name ↦ 𝑒-class-name,
+    name ↦ 𝑒-class,
     𝐵-class-body-head,
     𝜏-function ↦ ⟦
       φ ↦ Φ.jeo.method,
@@ -19,8 +19,8 @@ pattern: |
         𝐵-body-head,
         𝜏-invokedynamic ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokedynamic,
-          𝜏3 ↦ 𝑒-method-name,
-          𝜏4 ↦ 𝑒-interface-name,
+          𝜏3 ↦ 𝑒-method,
+          𝜏4 ↦ 𝑒-interface,
           𝜏5 ↦ ⟦
             φ ↦ Φ.jeo.handle,
             𝜏6 ↦ 6,
@@ -38,8 +38,8 @@ pattern: |
           𝜏13 ↦ ⟦
             φ ↦ Φ.jeo.handle,
             𝜏14 ↦ 6,
-            𝜏15 ↦ 𝑒-target-class-name,
-            𝜏16 ↦ 𝑒-target-method-name,
+            𝜏15 ↦ 𝑒-target-class,
+            𝜏16 ↦ 𝑒-target-method,
             𝜏17 ↦ 𝑒-target-signature,
             𝜏18 ↦ Φ̇.false,
             𝐵12
@@ -53,15 +53,15 @@ pattern: |
         ⟧,
         𝜏-invokeinterface ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokeinterface,
-          𝜏24 ↦ 𝑒-stream-class-name,
-          𝜏25 ↦ 𝑒-stream-method-name,
+          𝜏24 ↦ 𝑒-stream-class,
+          𝜏25 ↦ 𝑒-stream-method,
           𝜏26 ↦ 𝑒-stream-signature,
           𝜏27 ↦ Φ̇.true,
           𝐵15
         ⟧,
         𝐵-body-tail
       ⟧,
-      name ↦ 𝑒-function-name,
+      name ↦ 𝑒-function,
       ρ ↦ ∅
     ⟧,
     𝐵-class-body-tail
@@ -73,7 +73,7 @@ result: |
     access ↦ 𝑒-class-access,
     supername ↦ 𝑒-class-supername,
     interfaces ↦ 𝑒-class-interfaces,
-    name ↦ 𝑒-class-name,
+    name ↦ 𝑒-class,
     𝐵-class-body-head,
     𝜏-function ↦ ⟦
       φ ↦ Φ.jeo.method,
@@ -82,21 +82,21 @@ result: |
         𝐵-body-head,
         𝜏-lambda ↦ ⟦
           φ ↦ Φ.hone.lambda,
-          class ↦ 𝑒-class-name,
-          method ↦ 𝑒-method-name,
-          interface ↦ 𝑒-interface-name,
+          class ↦ 𝑒-class,
+          method ↦ 𝑒-method,
+          interface ↦ 𝑒-interface,
           lambda-signature ↦ 𝑒-lambda-signature,
-          target-class ↦ 𝑒-target-class-name,
-          target-method ↦ 𝑒-target-method-name,
+          target-class ↦ 𝑒-target-class,
+          target-method ↦ 𝑒-target-method,
           target-signature ↦ 𝑒-target-signature,
           bridge-signature ↦ 𝑒-bridge-signature,
-          stream-class ↦ 𝑒-stream-class-name,
-          stream-method ↦ 𝑒-stream-method-name,
+          stream-class ↦ 𝑒-stream-class,
+          stream-method ↦ 𝑒-stream-method,
           stream-signature ↦ 𝑒-stream-signature
         ⟧,
         𝐵-body-tail
       ⟧,
-      name ↦ 𝑒-function-name,
+      name ↦ 𝑒-function,
       ρ ↦ ∅
     ⟧,
     𝐵-class-body-tail

--- a/src/main/rules/201-lambda-to-filter.phr
+++ b/src/main/rules/201-lambda-to-filter.phr
@@ -10,34 +10,29 @@ pattern: |
     method ↦ "test",
     interface ↦ "()Ljava/util/function/Predicate;",
     lambda-signature ↦ "(Ljava/lang/Object;)Z",
+    target-handle ↦ 𝑒-target-handle,
     target-class ↦ 𝑒-target-class,
     target-method ↦ 𝑒-target-method,
     target-signature ↦ 𝑒-target-signature,
     bridge-signature ↦ 𝑒-bridge-signature,
     stream-class ↦ "java/util/stream/Stream",
     stream-method ↦ "filter",
-    stream-signature ↦ "(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;",
-    𝐵1
+    stream-signature ↦ "(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;"
   ⟧
 result: |
   ⟦
     φ ↦ Φ.hone.filter,
     class ↦ 𝑒-class,
+    target-handle ↦ 𝑒-target-handle,
     target-class ↦ 𝑒-target-class,
     target-method ↦ 𝑒-target-method,
-    target-input ↦ 𝑒-target-input,
+    target-signature ↦ 𝑒-target-signature,
     bridge-input ↦ 𝑒-bridge-input
   ⟧
 where:
-  - meta: 𝑒-target-input
-    function: sed
-    # "(Ljava/lang/Integer;)Z"
-    args:
-      - 𝑒-target-signature
-      - '"s/\\(L(.+);\\)Z/$1/g"'
   - meta: 𝑒-bridge-input
     function: sed
     # "(Ljava/lang/Integer;)Z"
     args:
       - 𝑒-bridge-signature
-      - '"s/\\(L(.+);\\)Z/$1/g"'
+      - '"s/\\((.*)\\)Z/$1/g"'

--- a/src/main/rules/201-lambda-to-filter.phr
+++ b/src/main/rules/201-lambda-to-filter.phr
@@ -6,12 +6,12 @@ name: lambda-to-filter
 pattern: |
   ⟦
     φ ↦ Φ.hone.lambda,
-    class ↦ 𝑒-class-name,
+    class ↦ 𝑒-class,
     method ↦ "test",
     interface ↦ "()Ljava/util/function/Predicate;",
     lambda-signature ↦ "(Ljava/lang/Object;)Z",
-    target-class ↦ 𝑒-target-class-name,
-    target-method ↦ 𝑒-target-method-name,
+    target-class ↦ 𝑒-target-class,
+    target-method ↦ 𝑒-target-method,
     target-signature ↦ 𝑒-target-signature,
     bridge-signature ↦ 𝑒-bridge-signature,
     stream-class ↦ "java/util/stream/Stream",
@@ -22,20 +22,20 @@ pattern: |
 result: |
   ⟦
     φ ↦ Φ.hone.filter,
-    class ↦ 𝑒-class-name,
-    target-class ↦ 𝑒-target-class-name,
-    target-method ↦ 𝑒-target-method-name,
-    target-input ↦ 𝑒-target-input-type,
-    bridge-input ↦ 𝑒-bridge-input-type
+    class ↦ 𝑒-class,
+    target-class ↦ 𝑒-target-class,
+    target-method ↦ 𝑒-target-method,
+    target-input ↦ 𝑒-target-input,
+    bridge-input ↦ 𝑒-bridge-input
   ⟧
 where:
-  - meta: 𝑒-target-input-type
+  - meta: 𝑒-target-input
     function: sed
     # "(Ljava/lang/Integer;)Z"
     args:
       - 𝑒-target-signature
       - '"s/\\(L(.+);\\)Z/$1/g"'
-  - meta: 𝑒-bridge-input-type
+  - meta: 𝑒-bridge-input
     function: sed
     # "(Ljava/lang/Integer;)Z"
     args:

--- a/src/main/rules/202-lambda-to-map.phr
+++ b/src/main/rules/202-lambda-to-map.phr
@@ -6,12 +6,12 @@ name: lambda-to-map
 pattern: |
   ⟦
     φ ↦ Φ.hone.lambda,
-    class ↦ 𝑒-class-name,
+    class ↦ 𝑒-class,
     method ↦ "apply",
     interface ↦ "()Ljava/util/function/Function;",
     lambda-signature ↦ "(Ljava/lang/Object;)Ljava/lang/Object;",
-    target-class ↦ 𝑒-target-class-name,
-    target-method ↦ 𝑒-target-method-name,
+    target-class ↦ 𝑒-target-class,
+    target-method ↦ 𝑒-target-method,
     target-signature ↦ 𝑒-target-signature,
     bridge-signature ↦ 𝑒-bridge-signature,
     stream-class ↦ "java/util/stream/Stream",
@@ -22,34 +22,34 @@ pattern: |
 result: |
   ⟦
     φ ↦ Φ.hone.map,
-    class ↦ 𝑒-class-name,
-    target-class ↦ 𝑒-target-class-name,
-    target-method ↦ 𝑒-target-method-name,
-    target-input ↦ 𝑒-target-input-type,
-    target-output ↦ 𝑒-target-output-type,
-    bridge-input ↦ 𝑒-bridge-input-type,
-    bridge-output ↦ 𝑒-bridge-output-type
+    class ↦ 𝑒-class,
+    target-class ↦ 𝑒-target-class,
+    target-method ↦ 𝑒-target-method,
+    target-input ↦ 𝑒-target-input,
+    target-output ↦ 𝑒-target-output,
+    bridge-input ↦ 𝑒-bridge-input,
+    bridge-output ↦ 𝑒-bridge-output
   ⟧
 where:
-  - meta: 𝑒-target-input-type
+  - meta: 𝑒-target-input
     function: sed
     # "(Ljava/lang/String;)Ljava/lang/Integer;"
     args:
       - 𝑒-target-signature
       - '"s/\\(L(.+);\\).*/$1/g"'
-  - meta: 𝑒-target-output-type
+  - meta: 𝑒-target-output
     function: sed
     # "(Ljava/lang/String;)Ljava/lang/Integer;"
     args:
       - 𝑒-target-signature
       - '"s/.*;\\)L(.+);/$1/g"'
-  - meta: 𝑒-bridge-input-type
+  - meta: 𝑒-bridge-input
     function: sed
     # "(Ljava/lang/String;)Ljava/lang/Integer;"
     args:
       - 𝑒-bridge-signature
       - '"s/\\(L(.+);\\).*/$1/g"'
-  - meta: 𝑒-bridge-output-type
+  - meta: 𝑒-bridge-output
     function: sed
     # "(Ljava/lang/String;)Ljava/lang/Integer;"
     args:

--- a/src/main/rules/202-lambda-to-map.phr
+++ b/src/main/rules/202-lambda-to-map.phr
@@ -10,48 +10,36 @@ pattern: |
     method ↦ "apply",
     interface ↦ "()Ljava/util/function/Function;",
     lambda-signature ↦ "(Ljava/lang/Object;)Ljava/lang/Object;",
+    target-handle ↦ 𝑒-target-handle, 
     target-class ↦ 𝑒-target-class,
     target-method ↦ 𝑒-target-method,
     target-signature ↦ 𝑒-target-signature,
     bridge-signature ↦ 𝑒-bridge-signature,
     stream-class ↦ "java/util/stream/Stream",
     stream-method ↦ "map",
-    stream-signature ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;",
-    𝐵1
+    stream-signature ↦ "(Ljava/util/function/Function;)Ljava/util/stream/Stream;"
   ⟧
 result: |
   ⟦
     φ ↦ Φ.hone.map,
     class ↦ 𝑒-class,
+    target-handle ↦ 𝑒-target-handle,
     target-class ↦ 𝑒-target-class,
     target-method ↦ 𝑒-target-method,
-    target-input ↦ 𝑒-target-input,
-    target-output ↦ 𝑒-target-output,
+    target-signature ↦ 𝑒-target-signature,
     bridge-input ↦ 𝑒-bridge-input,
     bridge-output ↦ 𝑒-bridge-output
   ⟧
 where:
-  - meta: 𝑒-target-input
-    function: sed
-    # "(Ljava/lang/String;)Ljava/lang/Integer;"
-    args:
-      - 𝑒-target-signature
-      - '"s/\\(L(.+);\\).*/$1/g"'
-  - meta: 𝑒-target-output
-    function: sed
-    # "(Ljava/lang/String;)Ljava/lang/Integer;"
-    args:
-      - 𝑒-target-signature
-      - '"s/.*;\\)L(.+);/$1/g"'
   - meta: 𝑒-bridge-input
     function: sed
     # "(Ljava/lang/String;)Ljava/lang/Integer;"
     args:
       - 𝑒-bridge-signature
-      - '"s/\\(L(.+);\\).*/$1/g"'
+      - '"s/\\((.*)\\).*/$1/g"'
   - meta: 𝑒-bridge-output
     function: sed
     # "(Ljava/lang/String;)Ljava/lang/Integer;"
     args:
       - 𝑒-bridge-signature
-      - '"s/.*;\\)L(.+);/$1/g"'
+      - '"s/\\(.*\\)(.+)/$1/g"'

--- a/src/main/rules/301-filter-to-distill.phr
+++ b/src/main/rules/301-filter-to-distill.phr
@@ -8,11 +8,11 @@ pattern: |
     𝐵-body-head,
     𝜏-opcode ↦ ⟦
       φ ↦ Φ.hone.filter,
-      class ↦ 𝑒-class-name,
-      target-class ↦ 𝑒-target-class-name,
-      target-method ↦ 𝑒-target-method-name,
-      target-input ↦ 𝑒-target-input-type,
-      bridge-input ↦ 𝑒-bridge-input-type
+      class ↦ 𝑒-class,
+      target-class ↦ 𝑒-target-class,
+      target-method ↦ 𝑒-target-method,
+      target-input ↦ 𝑒-target-input,
+      bridge-input ↦ 𝑒-bridge-input
     ⟧,
     𝐵-body-tail
   ⟧
@@ -21,14 +21,14 @@ result: |
     𝐵-body-head,
     𝜏-opcode ↦ ⟦
       φ ↦ Φ.hone.distill,
-      class ↦ 𝑒-class-name,
-      target-class ↦ 𝑒-target-class-name,
-      target-input ↦ 𝑒-target-input-type,
-      target-output ↦ 𝑒-target-input-type,
-      bridge-input ↦ 𝑒-bridge-input-type,
-      bridge-output ↦ 𝑒-bridge-input-type,
+      class ↦ 𝑒-class,
+      target-class ↦ 𝑒-target-class,
+      target-input ↦ 𝑒-target-input,
+      target-output ↦ 𝑒-target-input,
+      bridge-input ↦ 𝑒-bridge-input,
+      bridge-output ↦ 𝑒-bridge-input,
       locals ↦ ⟦
-        item ↦ 𝑒-bridge-input-type,
+        item ↦ 𝑒-bridge-input,
         consumer ↦ "java/util/function/Consumer"
       ⟧,
       body ↦ ⟦
@@ -37,8 +37,8 @@ result: |
         ⟧,
         i1 ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokestatic,
-          i2 ↦ 𝑒-target-class-name,
-          i3 ↦ 𝑒-target-method-name,
+          i2 ↦ 𝑒-target-class,
+          i3 ↦ 𝑒-target-method,
           i4 ↦ 𝑒-signature,
           i5 ↦ Φ̇.false
         ⟧,
@@ -68,5 +68,5 @@ where:
     function: concat
     args:
       - '"(L"'
-      - 𝑒-target-input-type
+      - 𝑒-target-input
       - '";)Z"'

--- a/src/main/rules/301-filter-to-distill.phr
+++ b/src/main/rules/301-filter-to-distill.phr
@@ -9,9 +9,10 @@ pattern: |
     𝜏-opcode ↦ ⟦
       φ ↦ Φ.hone.filter,
       class ↦ 𝑒-class,
+      target-handle ↦ 𝑒-target-handle,
       target-class ↦ 𝑒-target-class,
       target-method ↦ 𝑒-target-method,
-      target-input ↦ 𝑒-target-input,
+      target-signature ↦ 𝑒-target-signature,
       bridge-input ↦ 𝑒-bridge-input
     ⟧,
     𝐵-body-tail
@@ -22,13 +23,10 @@ result: |
     𝜏-opcode ↦ ⟦
       φ ↦ Φ.hone.distill,
       class ↦ 𝑒-class,
-      target-class ↦ 𝑒-target-class,
-      target-input ↦ 𝑒-target-input,
-      target-output ↦ 𝑒-target-input,
       bridge-input ↦ 𝑒-bridge-input,
       bridge-output ↦ 𝑒-bridge-input,
       locals ↦ ⟦
-        item ↦ 𝑒-bridge-input,
+        item ↦ 𝑒-item-type,
         consumer ↦ "java/util/function/Consumer"
       ⟧,
       body ↦ ⟦
@@ -39,7 +37,7 @@ result: |
           φ ↦ Φ.jeo.opcode.invokestatic,
           i2 ↦ 𝑒-target-class,
           i3 ↦ 𝑒-target-method,
-          i4 ↦ 𝑒-signature,
+          i4 ↦ 𝑒-target-signature,
           i5 ↦ Φ̇.false
         ⟧,
         i2 ↦ ⟦
@@ -64,9 +62,8 @@ where:
   - meta: 𝑒-label
     function: random-string
     args: ['"L%d"']
-  - meta: 𝑒-signature
-    function: concat
+  - meta: 𝑒-item-type
+    function: sed
     args:
-      - '"(L"'
-      - 𝑒-target-input
-      - '";)Z"'
+      - 𝑒-bridge-input
+      - '"s/L(.+);/$1/g"'

--- a/src/main/rules/302-map-to-distill.phr
+++ b/src/main/rules/302-map-to-distill.phr
@@ -8,13 +8,13 @@ pattern: |
     𝐵-body-head,
     𝜏-opcode ↦ ⟦
       φ ↦ Φ.hone.map,
-      class ↦ 𝑒-class-name,
-      target-class ↦ 𝑒-target-class-name,
-      target-method ↦ 𝑒-target-method-name,
-      target-input ↦ 𝑒-target-input-type,
-      target-output ↦ 𝑒-target-output-type,
-      bridge-input ↦ 𝑒-bridge-input-type,
-      bridge-output ↦ 𝑒-bridge-output-type
+      class ↦ 𝑒-class,
+      target-class ↦ 𝑒-target-class,
+      target-method ↦ 𝑒-target-method,
+      target-input ↦ 𝑒-target-input,
+      target-output ↦ 𝑒-target-output,
+      bridge-input ↦ 𝑒-bridge-input,
+      bridge-output ↦ 𝑒-bridge-output
     ⟧,
     𝐵-body-tail
   ⟧
@@ -23,21 +23,21 @@ result: |
     𝐵-body-head,
     𝜏-opcode ↦ ⟦
       φ ↦ Φ.hone.distill,
-      class ↦ 𝑒-class-name,
-      target-class ↦ 𝑒-target-class-name,
-      target-input ↦ 𝑒-target-input-type,
-      target-output ↦ 𝑒-target-output-type,
-      bridge-input ↦ 𝑒-bridge-input-type,
-      bridge-output ↦ 𝑒-bridge-output-type,
+      class ↦ 𝑒-class,
+      target-class ↦ 𝑒-target-class,
+      target-input ↦ 𝑒-target-input,
+      target-output ↦ 𝑒-target-output,
+      bridge-input ↦ 𝑒-bridge-input,
+      bridge-output ↦ 𝑒-bridge-output,
       locals ↦ ⟦
-        item ↦ 𝑒-bridge-input-type,
+        item ↦ 𝑒-bridge-input,
         consumer ↦ "java/util/function/Consumer"
       ⟧,
       body ↦ ⟦
         i1 ↦ ⟦
           φ ↦ Φ.jeo.opcode.invokestatic,
-          i2 ↦ 𝑒-target-class-name,
-          i3 ↦ 𝑒-target-method-name,
+          i2 ↦ 𝑒-target-class,
+          i3 ↦ 𝑒-target-method,
           i4 ↦ 𝑒-signature,
           i5 ↦ Φ̇.false
         ⟧
@@ -50,7 +50,7 @@ where:
     function: concat
     args:
       - '"(L"'
-      - 𝑒-target-input-type
+      - 𝑒-target-input
       - '";)L"'
-      - 𝑒-target-output-type
+      - 𝑒-target-output
       - '";"'

--- a/src/main/rules/302-map-to-distill.phr
+++ b/src/main/rules/302-map-to-distill.phr
@@ -9,10 +9,10 @@ pattern: |
     𝜏-opcode ↦ ⟦
       φ ↦ Φ.hone.map,
       class ↦ 𝑒-class,
+      target-handle ↦ 𝑒-target-handle,
       target-class ↦ 𝑒-target-class,
       target-method ↦ 𝑒-target-method,
-      target-input ↦ 𝑒-target-input,
-      target-output ↦ 𝑒-target-output,
+      target-signature ↦ 𝑒-target-signature,
       bridge-input ↦ 𝑒-bridge-input,
       bridge-output ↦ 𝑒-bridge-output
     ⟧,
@@ -24,13 +24,10 @@ result: |
     𝜏-opcode ↦ ⟦
       φ ↦ Φ.hone.distill,
       class ↦ 𝑒-class,
-      target-class ↦ 𝑒-target-class,
-      target-input ↦ 𝑒-target-input,
-      target-output ↦ 𝑒-target-output,
       bridge-input ↦ 𝑒-bridge-input,
       bridge-output ↦ 𝑒-bridge-output,
       locals ↦ ⟦
-        item ↦ 𝑒-bridge-input,
+        item ↦ 𝑒-item-type,
         consumer ↦ "java/util/function/Consumer"
       ⟧,
       body ↦ ⟦
@@ -38,7 +35,7 @@ result: |
           φ ↦ Φ.jeo.opcode.invokestatic,
           i2 ↦ 𝑒-target-class,
           i3 ↦ 𝑒-target-method,
-          i4 ↦ 𝑒-signature,
+          i4 ↦ 𝑒-target-signature,
           i5 ↦ Φ̇.false
         ⟧
       ⟧
@@ -46,11 +43,8 @@ result: |
     𝐵-body-tail
   ⟧
 where:
-  - meta: 𝑒-signature
-    function: concat
+  - meta: 𝑒-item-type
+    function: sed
     args:
-      - '"(L"'
-      - 𝑒-target-input
-      - '";)L"'
-      - 𝑒-target-output
-      - '";"'
+      - 𝑒-bridge-input
+      - '"s/L(.+);/$1/g"'

--- a/src/main/rules/401-fuse.phr
+++ b/src/main/rules/401-fuse.phr
@@ -9,9 +9,6 @@ pattern: |
     𝜏-first ↦ ⟦
       φ ↦ Φ.hone.distill,
       class ↦ 𝑒-class,
-      target-class ↦ 𝑒-first-target-class,
-      target-input ↦ 𝑒-first-target-input,
-      target-output ↦ 𝑒-first-target-output,
       bridge-input ↦ 𝑒-first-bridge-input,
       bridge-output ↦ 𝑒-first-bridge-output,
       locals ↦ ⟦ 𝐵-locals, ρ ↦ ∅ ⟧,
@@ -20,9 +17,6 @@ pattern: |
     𝜏-second ↦ ⟦
       φ ↦ Φ.hone.distill,
       class ↦ 𝑒-class,
-      target-class ↦ 𝑒-second-target-class,
-      target-input ↦ 𝑒-second-target-input,
-      target-output ↦ 𝑒-second-target-output,
       bridge-input ↦ 𝑒-second-bridge-input,
       bridge-output ↦ 𝑒-second-bridge-output,
       locals ↦ 𝑒-second-locals,
@@ -36,14 +30,11 @@ result: |
     𝜏-first ↦ ⟦
       φ ↦ Φ.hone.distill,
       class ↦ 𝑒-class,
-      target-class ↦ 𝑒-class,
-      target-input ↦ 𝑒-first-target-input,
-      target-output ↦ 𝑒-second-target-output,
       bridge-input ↦ 𝑒-first-bridge-input,
       bridge-output ↦ 𝑒-second-bridge-output,
       locals ↦ ⟦
         𝐵-locals,
-        local ↦ 𝑒-first-bridge-output,
+        𝜏-local ↦ 𝑒-item-type,
         ρ ↦ ∅
       ⟧,
       body ↦ ⟦
@@ -60,7 +51,7 @@ result: |
           stack ↦ ⟦
             φ ↦ Φ.jeo.seq.of2,
             consumer ↦ "java/util/function/Consumer",
-            item ↦ 𝑒-first-bridge-output
+            item ↦ 𝑒-item-type
           ⟧
         ⟧,
         i-store ↦ ⟦
@@ -81,3 +72,11 @@ where:
   - meta: 𝑒-locals-size
     function: size
     args: [ 𝐵-locals ]
+  - meta: 𝜏-local
+    function: random-tau
+    args: [ 𝐵-locals ]
+  - meta: 𝑒-item-type
+    function: sed
+    args:
+      - 𝑒-first-bridge-output
+      - '"s/L(.+);/$1/g"'

--- a/src/main/rules/401-fuse.phr
+++ b/src/main/rules/401-fuse.phr
@@ -8,23 +8,23 @@ pattern: |
     𝐵-body-head,
     𝜏-first ↦ ⟦
       φ ↦ Φ.hone.distill,
-      class ↦ 𝑒-class-name,
-      target-class ↦ 𝑒-first-target-class-name,
-      target-input ↦ 𝑒-first-target-input-type,
-      target-output ↦ 𝑒-first-target-output-type,
-      bridge-input ↦ 𝑒-first-bridge-input-type,
-      bridge-output ↦ 𝑒-first-bridge-output-type,
+      class ↦ 𝑒-class,
+      target-class ↦ 𝑒-first-target-class,
+      target-input ↦ 𝑒-first-target-input,
+      target-output ↦ 𝑒-first-target-output,
+      bridge-input ↦ 𝑒-first-bridge-input,
+      bridge-output ↦ 𝑒-first-bridge-output,
       locals ↦ ⟦ 𝐵-locals, ρ ↦ ∅ ⟧,
       body ↦ ⟦ 𝐵-first-body, ρ ↦ ∅ ⟧
     ⟧,
     𝜏-second ↦ ⟦
       φ ↦ Φ.hone.distill,
-      class ↦ 𝑒-class-name,
-      target-class ↦ 𝑒-second-target-class-name,
-      target-input ↦ 𝑒-second-target-input-type,
-      target-output ↦ 𝑒-second-target-output-type,
-      bridge-input ↦ 𝑒-second-bridge-input-type,
-      bridge-output ↦ 𝑒-second-bridge-output-type,
+      class ↦ 𝑒-class,
+      target-class ↦ 𝑒-second-target-class,
+      target-input ↦ 𝑒-second-target-input,
+      target-output ↦ 𝑒-second-target-output,
+      bridge-input ↦ 𝑒-second-bridge-input,
+      bridge-output ↦ 𝑒-second-bridge-output,
       locals ↦ 𝑒-second-locals,
       body ↦ ⟦ 𝐵-second-body, ρ ↦ ∅ ⟧
     ⟧,
@@ -35,15 +35,15 @@ result: |
     𝐵-body-head,
     𝜏-first ↦ ⟦
       φ ↦ Φ.hone.distill,
-      class ↦ 𝑒-class-name,
-      target-class ↦ 𝑒-class-name,
-      target-input ↦ 𝑒-first-target-input-type,
-      target-output ↦ 𝑒-second-target-output-type,
-      bridge-input ↦ 𝑒-first-bridge-input-type,
-      bridge-output ↦ 𝑒-second-bridge-output-type,
+      class ↦ 𝑒-class,
+      target-class ↦ 𝑒-class,
+      target-input ↦ 𝑒-first-target-input,
+      target-output ↦ 𝑒-second-target-output,
+      bridge-input ↦ 𝑒-first-bridge-input,
+      bridge-output ↦ 𝑒-second-bridge-output,
       locals ↦ ⟦
         𝐵-locals,
-        local ↦ 𝑒-first-bridge-output-type,
+        local ↦ 𝑒-first-bridge-output,
         ρ ↦ ∅
       ⟧,
       body ↦ ⟦
@@ -60,7 +60,7 @@ result: |
           stack ↦ ⟦
             φ ↦ Φ.jeo.seq.of2,
             consumer ↦ "java/util/function/Consumer",
-            item ↦ 𝑒-first-bridge-output-type
+            item ↦ 𝑒-first-bridge-output
           ⟧
         ⟧,
         i-store ↦ ⟦

--- a/src/main/rules/402-clear-frames.phr
+++ b/src/main/rules/402-clear-frames.phr
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+name: clear-frames
+pattern: |
+  ⟦
+    φ ↦ Φ.hone.distill,
+    class ↦ 𝑒-class,
+    bridge-input ↦ 𝑒-bridge-input,
+    bridge-output ↦ 𝑒-bridge-output,
+    locals ↦ ⟦ 𝐵-locals ⟧,
+    body ↦ ⟦
+      𝐵-body-before,
+      𝜏-map ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokestatic,
+        𝐵-map-rest
+      ⟧,
+      𝜏-frame ↦ ⟦
+        φ ↦ Φ.jeo.frame,
+        𝐵-frame-rest
+      ⟧,
+      𝐵-body-after
+    ⟧
+  ⟧
+result: |
+  ⟦
+    φ ↦ Φ.hone.distill,
+    class ↦ 𝑒-class,
+    bridge-input ↦ 𝑒-bridge-input,
+    bridge-output ↦ 𝑒-bridge-output,
+    locals ↦ ⟦ 𝐵-locals ⟧,
+    body ↦ ⟦
+      𝐵-body-before,
+      𝜏-map ↦ ⟦
+        φ ↦ Φ.jeo.opcode.invokestatic,
+        𝐵-map-rest
+      ⟧,
+      𝐵-body-after
+    ⟧
+  ⟧

--- a/src/main/rules/501-distill-to-mapMulti.phr
+++ b/src/main/rules/501-distill-to-mapMulti.phr
@@ -14,12 +14,12 @@ pattern: |
         𝐵-body-head,
         𝜏-distill ↦ ⟦
           φ ↦ Φ.hone.distill,
-          class ↦ 𝑒-class-name,
-          target-class ↦ 𝑒-target-class-name,
-          target-input ↦ 𝑒-target-input-type,
-          target-output ↦ 𝑒-target-output-type,
-          bridge-input ↦ 𝑒-bridge-input-type,
-          bridge-output ↦ 𝑒-bridge-output-type,
+          class ↦ 𝑒-class,
+          target-class ↦ 𝑒-target-class,
+          target-input ↦ 𝑒-target-input,
+          target-output ↦ 𝑒-target-output,
+          bridge-input ↦ 𝑒-bridge-input,
+          bridge-output ↦ 𝑒-bridge-output,
           locals ↦ ⟦ 𝐵-locals, ρ ↦ ∅ ⟧,
           body ↦ ⟦ 𝐵-body, ρ ↦ ∅ ⟧
         ⟧,
@@ -40,11 +40,11 @@ result: |
         𝐵-body-head,
         𝜏-distill ↦ ⟦
           φ ↦ Φ.hone.mapMulti,
-          class ↦ 𝑒-class-name,
-          target-class ↦ 𝑒-target-class-name,
-          target-method ↦ 𝑒-target-method-name,
-          target-input ↦ 𝑒-target-input-type,
-          bridge-input ↦ 𝑒-bridge-input-type
+          class ↦ 𝑒-class,
+          target-class ↦ 𝑒-target-class,
+          target-method ↦ 𝑒-target-method,
+          target-input ↦ 𝑒-target-input,
+          bridge-input ↦ 𝑒-bridge-input
         ⟧,
         𝐵-body-tail
       ⟧,
@@ -99,7 +99,7 @@ result: |
           stack ↦ ⟦
             φ ↦ Φ.jeo.seq.of2,
             consumer ↦ "java/util/function/Consumer",
-            item ↦ 𝑒-bridge-output-type
+            item ↦ 𝑒-bridge-output
           ⟧
         ⟧,
         i-invoke ↦ ⟦
@@ -114,7 +114,7 @@ result: |
         ⟧,
         ρ ↦ ∅
       ⟧,
-      name ↦ 𝑒-target-method-name
+      name ↦ 𝑒-target-method
     ⟧
   ⟧
 where:
@@ -122,12 +122,12 @@ where:
     function: concat
     args:
       - '"L"'
-      - 𝑒-bridge-input-type
+      - 𝑒-bridge-input
       - '";"'
   - meta: 𝜏-reduce
     function: random-tau
     args: ['name', '𝐵-class-head', '𝐵-class-tail']
-  - meta: 𝑒-target-method-name
+  - meta: 𝑒-target-method
     function: random-string
     args: [ '"reduce_%d"' ]
   - meta: 𝑒-signature

--- a/src/main/rules/501-distill-to-mapMulti.phr
+++ b/src/main/rules/501-distill-to-mapMulti.phr
@@ -15,9 +15,6 @@ pattern: |
         𝜏-distill ↦ ⟦
           φ ↦ Φ.hone.distill,
           class ↦ 𝑒-class,
-          target-class ↦ 𝑒-target-class,
-          target-input ↦ 𝑒-target-input,
-          target-output ↦ 𝑒-target-output,
           bridge-input ↦ 𝑒-bridge-input,
           bridge-output ↦ 𝑒-bridge-output,
           locals ↦ ⟦ 𝐵-locals, ρ ↦ ∅ ⟧,
@@ -41,9 +38,7 @@ result: |
         𝜏-distill ↦ ⟦
           φ ↦ Φ.hone.mapMulti,
           class ↦ 𝑒-class,
-          target-class ↦ 𝑒-target-class,
           target-method ↦ 𝑒-target-method,
-          target-input ↦ 𝑒-target-input,
           bridge-input ↦ 𝑒-bridge-input
         ⟧,
         𝐵-body-tail
@@ -51,7 +46,7 @@ result: |
       𝐵-method-tail
     ⟧,
     𝐵-class-tail,
-    𝜏-reduce ↦ ⟦
+    𝜏-distill-lambda ↦ ⟦
       φ ↦ Φ.jeo.method,
       access ↦ 4106,
       descriptor ↦ 𝑒-signature,
@@ -67,7 +62,7 @@ result: |
           φ ↦ Φ.jeo.param,
           index ↦ 0,
           access ↦ 0,
-          type ↦ 𝑒-input-param
+          type ↦ 𝑒-bridge-input
         ⟧,
         i2 ↦ ⟦
           φ ↦ Φ.jeo.param,
@@ -99,7 +94,7 @@ result: |
           stack ↦ ⟦
             φ ↦ Φ.jeo.seq.of2,
             consumer ↦ "java/util/function/Consumer",
-            item ↦ 𝑒-bridge-output
+            item ↦ 𝑒-stack-item-type
           ⟧
         ⟧,
         i-invoke ↦ ⟦
@@ -118,24 +113,23 @@ result: |
     ⟧
   ⟧
 where:
-  - meta: 𝑒-input-param
-    function: concat
-    args:
-      - '"L"'
-      - 𝑒-bridge-input
-      - '";"'
-  - meta: 𝜏-reduce
+  - meta: 𝜏-distill-lambda
     function: random-tau
     args: ['name', '𝐵-class-head', '𝐵-class-tail']
   - meta: 𝑒-target-method
     function: random-string
-    args: [ '"reduce_%d"' ]
+    args: [ '"distill_%d"' ]
   - meta: 𝑒-signature
     function: concat
     args:
       - '"("'
-      - 𝑒-input-param
+      - 𝑒-bridge-input
       - '"Ljava/util/function/Consumer;)V"'
   - meta: 𝑒-max-locals
     function: size
     args: [ 𝐵-locals ]
+  - meta: 𝑒-stack-item-type
+    function: sed
+    args:
+      - 𝑒-bridge-output
+      - '"s/L(.+);/$1/g"'

--- a/src/main/rules/601-filter-to-lambda.phr
+++ b/src/main/rules/601-filter-to-lambda.phr
@@ -8,11 +8,11 @@ pattern: |
     𝐵-body-head,
     𝜏-map ↦ ⟦
       φ ↦ Φ.hone.filter,
-      class ↦ 𝑒-class-name,
-      target-class ↦ 𝑒-target-class-name,
-      target-method ↦ 𝑒-target-method-name,
-      target-input ↦ 𝑒-target-input-type,
-      bridge-input ↦ 𝑒-bridge-input-type
+      class ↦ 𝑒-class,
+      target-class ↦ 𝑒-target-class,
+      target-method ↦ 𝑒-target-method,
+      target-input ↦ 𝑒-target-input,
+      bridge-input ↦ 𝑒-bridge-input
     ⟧,
     𝐵-body-tail
   ⟧
@@ -21,12 +21,12 @@ result: |
     𝐵-body-head,
     𝜏-map ↦ ⟦
       φ ↦ Φ.hone.lambda,
-      class ↦ 𝑒-class-name,
+      class ↦ 𝑒-class,
       method ↦ "test",
       interface ↦ "()Ljava/util/function/Predicate;",
       lambda-signature ↦ "(Ljava/lang/Object;)Z",
-      target-class ↦ 𝑒-target-class-name,
-      target-method ↦ 𝑒-target-method-name,
+      target-class ↦ 𝑒-target-class,
+      target-method ↦ 𝑒-target-method,
       target-signature ↦ 𝑒-target-signature,
       bridge-signature ↦ 𝑒-bridge-signature,
       stream-class ↦ "java/util/stream/Stream",
@@ -40,11 +40,11 @@ where:
     function: concat
     args:
       - '"(L"'
-      - 𝑒-target-input-type
+      - 𝑒-target-input
       - '";)Z"'
   - meta: 𝑒-bridge-signature
     function: concat
     args:
       - '"(L"'
-      - 𝑒-bridge-input-type
+      - 𝑒-bridge-input
       - '";)Z"'

--- a/src/main/rules/601-filter-to-lambda.phr
+++ b/src/main/rules/601-filter-to-lambda.phr
@@ -9,9 +9,10 @@ pattern: |
     𝜏-map ↦ ⟦
       φ ↦ Φ.hone.filter,
       class ↦ 𝑒-class,
+      target-handle ↦ 𝑒-target-handle,
       target-class ↦ 𝑒-target-class,
       target-method ↦ 𝑒-target-method,
-      target-input ↦ 𝑒-target-input,
+      target-signature ↦ 𝑒-target-signature,
       bridge-input ↦ 𝑒-bridge-input
     ⟧,
     𝐵-body-tail
@@ -25,6 +26,7 @@ result: |
       method ↦ "test",
       interface ↦ "()Ljava/util/function/Predicate;",
       lambda-signature ↦ "(Ljava/lang/Object;)Z",
+      target-handle ↦ 𝑒-target-handle,
       target-class ↦ 𝑒-target-class,
       target-method ↦ 𝑒-target-method,
       target-signature ↦ 𝑒-target-signature,
@@ -36,15 +38,9 @@ result: |
     𝐵-body-tail
   ⟧
 where:
-  - meta: 𝑒-target-signature
-    function: concat
-    args:
-      - '"(L"'
-      - 𝑒-target-input
-      - '";)Z"'
   - meta: 𝑒-bridge-signature
     function: concat
     args:
-      - '"(L"'
+      - '"("'
       - 𝑒-bridge-input
-      - '";)Z"'
+      - '")Z"'

--- a/src/main/rules/602-map-to-lambda.phr
+++ b/src/main/rules/602-map-to-lambda.phr
@@ -9,10 +9,10 @@ pattern: |
     𝜏-map ↦ ⟦
       φ ↦ Φ.hone.map,
       class ↦ 𝑒-class,
+      target-handle ↦ 𝑒-target-handle,
       target-class ↦ 𝑒-target-class,
       target-method ↦ 𝑒-target-method,
-      target-input ↦ 𝑒-target-input,
-      target-output ↦ 𝑒-target-output,
+      target-signature ↦ 𝑒-target-signature,
       bridge-input ↦ 𝑒-bridge-input,
       bridge-output ↦ 𝑒-bridge-output
     ⟧,
@@ -27,6 +27,7 @@ result: |
       method ↦ "apply",
       interface ↦ "()Ljava/util/function/Function;",
       lambda-signature ↦ "(Ljava/lang/Object;)Ljava/lang/Object;",
+      target-handle ↦ 𝑒-target-handle,
       target-class ↦ 𝑒-target-class,
       target-method ↦ 𝑒-target-method,
       target-signature ↦ 𝑒-target-signature,
@@ -38,19 +39,10 @@ result: |
     𝐵-body-tail
   ⟧
 where:
-  - meta: 𝑒-target-signature
-    function: concat
-    args:
-      - '"(L"'
-      - 𝑒-target-input
-      - '";)L"'
-      - 𝑒-target-output
-      - '";"'
   - meta: 𝑒-bridge-signature
     function: concat
     args:
-      - '"(L"'
+      - '"("'
       - 𝑒-bridge-input
-      - '";)L"'
+      - '")"'
       - 𝑒-bridge-output
-      - '";"'

--- a/src/main/rules/602-map-to-lambda.phr
+++ b/src/main/rules/602-map-to-lambda.phr
@@ -8,13 +8,13 @@ pattern: |
     𝐵-body-head,
     𝜏-map ↦ ⟦
       φ ↦ Φ.hone.map,
-      class ↦ 𝑒-class-name,
-      target-class ↦ 𝑒-target-class-name,
-      target-method ↦ 𝑒-target-method-name,
-      target-input ↦ 𝑒-target-input-type,
-      target-output ↦ 𝑒-target-output-type,
-      bridge-input ↦ 𝑒-bridge-input-type,
-      bridge-output ↦ 𝑒-bridge-output-type
+      class ↦ 𝑒-class,
+      target-class ↦ 𝑒-target-class,
+      target-method ↦ 𝑒-target-method,
+      target-input ↦ 𝑒-target-input,
+      target-output ↦ 𝑒-target-output,
+      bridge-input ↦ 𝑒-bridge-input,
+      bridge-output ↦ 𝑒-bridge-output
     ⟧,
     𝐵-body-tail
   ⟧
@@ -23,12 +23,12 @@ result: |
     𝐵-body-head,
     𝜏-map ↦ ⟦
       φ ↦ Φ.hone.lambda,
-      class ↦ 𝑒-class-name,
+      class ↦ 𝑒-class,
       method ↦ "apply",
       interface ↦ "()Ljava/util/function/Function;",
       lambda-signature ↦ "(Ljava/lang/Object;)Ljava/lang/Object;",
-      target-class ↦ 𝑒-target-class-name,
-      target-method ↦ 𝑒-target-method-name,
+      target-class ↦ 𝑒-target-class,
+      target-method ↦ 𝑒-target-method,
       target-signature ↦ 𝑒-target-signature,
       bridge-signature ↦ 𝑒-bridge-signature,
       stream-class ↦ "java/util/stream/Stream",
@@ -42,15 +42,15 @@ where:
     function: concat
     args:
       - '"(L"'
-      - 𝑒-target-input-type
+      - 𝑒-target-input
       - '";)L"'
-      - 𝑒-target-output-type
+      - 𝑒-target-output
       - '";"'
   - meta: 𝑒-bridge-signature
     function: concat
     args:
       - '"(L"'
-      - 𝑒-bridge-input-type
+      - 𝑒-bridge-input
       - '";)L"'
-      - 𝑒-bridge-output-type
+      - 𝑒-bridge-output
       - '";"'

--- a/src/main/rules/603-mapMulti-to-lambda.phr
+++ b/src/main/rules/603-mapMulti-to-lambda.phr
@@ -9,9 +9,7 @@ pattern: |
     𝜏-map ↦ ⟦
       φ ↦ Φ.hone.mapMulti,
       class ↦ 𝑒-class,
-      target-class ↦ 𝑒-target-class,
       target-method ↦ 𝑒-target-method,
-      target-input ↦ 𝑒-target-input,
       bridge-input ↦ 𝑒-bridge-input
     ⟧,
     𝐵-body-tail
@@ -25,6 +23,7 @@ result: |
       method ↦ "accept",
       interface ↦ "()Ljava/util/function/BiConsumer;",
       lambda-signature ↦ "(Ljava/lang/Object;Ljava/lang/Object;)V",
+      target-handle ↦ 6,
       target-class ↦ 𝑒-class,
       target-method ↦ 𝑒-target-method,
       target-signature ↦ 𝑒-bridge-signature,
@@ -39,6 +38,6 @@ where:
   - meta: 𝑒-bridge-signature
     function: concat
     args:
-      - '"(L"'
+      - '"("'
       - 𝑒-bridge-input
-      - '";Ljava/util/function/Consumer;)V"'
+      - '"Ljava/util/function/Consumer;)V"'

--- a/src/main/rules/603-mapMulti-to-lambda.phr
+++ b/src/main/rules/603-mapMulti-to-lambda.phr
@@ -8,11 +8,11 @@ pattern: |
     𝐵-body-head,
     𝜏-map ↦ ⟦
       φ ↦ Φ.hone.mapMulti,
-      class ↦ 𝑒-class-name,
-      target-class ↦ 𝑒-target-class-name,
-      target-method ↦ 𝑒-target-method-name,
-      target-input ↦ 𝑒-target-input-type,
-      bridge-input ↦ 𝑒-bridge-input-type
+      class ↦ 𝑒-class,
+      target-class ↦ 𝑒-target-class,
+      target-method ↦ 𝑒-target-method,
+      target-input ↦ 𝑒-target-input,
+      bridge-input ↦ 𝑒-bridge-input
     ⟧,
     𝐵-body-tail
   ⟧
@@ -21,12 +21,12 @@ result: |
     𝐵-body-head,
     𝜏-map ↦ ⟦
       φ ↦ Φ.hone.lambda,
-      class ↦ 𝑒-class-name,
+      class ↦ 𝑒-class,
       method ↦ "accept",
       interface ↦ "()Ljava/util/function/BiConsumer;",
       lambda-signature ↦ "(Ljava/lang/Object;Ljava/lang/Object;)V",
-      target-class ↦ 𝑒-class-name,
-      target-method ↦ 𝑒-target-method-name,
+      target-class ↦ 𝑒-class,
+      target-method ↦ 𝑒-target-method,
       target-signature ↦ 𝑒-bridge-signature,
       bridge-signature ↦ 𝑒-bridge-signature,
       stream-class ↦ "java/util/stream/Stream",
@@ -40,5 +40,5 @@ where:
     function: concat
     args:
       - '"(L"'
-      - 𝑒-bridge-input-type
+      - 𝑒-bridge-input
       - '";Ljava/util/function/Consumer;)V"'

--- a/src/main/rules/701-lambda-to-invokedynamic.phr
+++ b/src/main/rules/701-lambda-to-invokedynamic.phr
@@ -5,13 +5,14 @@
 name: lambda-to-invokedynamic
 pattern: |
   ⟦
-    𝐵1,
-    𝜏1 ↦ ⟦
+    𝐵-before,
+    𝜏-lambda ↦ ⟦
       φ ↦ Φ.hone.lambda,
       class ↦ 𝑒-class,
       method ↦ 𝑒-method,
       interface ↦ 𝑒-interface,
       lambda-signature ↦ 𝑒-lambda-signature,
+      target-handle ↦ 𝑒-target-handle,
       target-class ↦ 𝑒-target-class,
       target-method ↦ 𝑒-target-method,
       target-signature ↦ 𝑒-target-signature,
@@ -20,11 +21,11 @@ pattern: |
       stream-method ↦ 𝑒-stream-method,
       stream-signature ↦ 𝑒-stream-signature
     ⟧,
-    𝐵2
+    𝐵-after
   ⟧
 result: |
   ⟦
-    𝐵1,
+    𝐵-before,
     𝜏-invokedynamic ↦ ⟦
       φ ↦ Φ.jeo.opcode.invokedynamic,
       i2 ↦ 𝑒-method,
@@ -43,7 +44,7 @@ result: |
       ⟧,
       i6 ↦ ⟦
         φ ↦ Φ.jeo.handle,
-        i1 ↦ 6,
+        i1 ↦ 𝑒-target-handle,
         i2 ↦ 𝑒-target-class,
         i3 ↦ 𝑒-target-method,
         i4 ↦ 𝑒-target-signature,
@@ -61,12 +62,12 @@ result: |
       i4 ↦ 𝑒-stream-signature,
       i5 ↦ Φ̇.true
     ⟧,
-    𝐵2
+    𝐵-after
   ⟧
 where:
   - meta: 𝜏-invokedynamic
     function: random-tau
-    args: ['𝐵1', '𝐵2']
+    args: ['𝐵-before', '𝐵-after']
   - meta: 𝜏-invokeinterface
     function: random-tau
-    args: ['𝐵1', '𝜏-invokedynamic', '𝐵2']
+    args: ['𝐵-before', '𝜏-invokedynamic', '𝐵-after']

--- a/src/main/rules/701-lambda-to-invokedynamic.phr
+++ b/src/main/rules/701-lambda-to-invokedynamic.phr
@@ -8,16 +8,16 @@ pattern: |
     𝐵1,
     𝜏1 ↦ ⟦
       φ ↦ Φ.hone.lambda,
-      class ↦ 𝑒-class-name,
-      method ↦ 𝑒-method-name,
-      interface ↦ 𝑒-interface-name,
+      class ↦ 𝑒-class,
+      method ↦ 𝑒-method,
+      interface ↦ 𝑒-interface,
       lambda-signature ↦ 𝑒-lambda-signature,
-      target-class ↦ 𝑒-target-class-name,
-      target-method ↦ 𝑒-target-method-name,
+      target-class ↦ 𝑒-target-class,
+      target-method ↦ 𝑒-target-method,
       target-signature ↦ 𝑒-target-signature,
       bridge-signature ↦ 𝑒-bridge-signature,
-      stream-class ↦ 𝑒-stream-class-name,
-      stream-method ↦ 𝑒-stream-method-name,
+      stream-class ↦ 𝑒-stream-class,
+      stream-method ↦ 𝑒-stream-method,
       stream-signature ↦ 𝑒-stream-signature
     ⟧,
     𝐵2
@@ -27,8 +27,8 @@ result: |
     𝐵1,
     𝜏-invokedynamic ↦ ⟦
       φ ↦ Φ.jeo.opcode.invokedynamic,
-      i2 ↦ 𝑒-method-name,
-      i3 ↦ 𝑒-interface-name,
+      i2 ↦ 𝑒-method,
+      i3 ↦ 𝑒-interface,
       i4 ↦ ⟦
         φ ↦ Φ.jeo.handle,
         i1 ↦ 6,
@@ -44,8 +44,8 @@ result: |
       i6 ↦ ⟦
         φ ↦ Φ.jeo.handle,
         i1 ↦ 6,
-        i2 ↦ 𝑒-target-class-name,
-        i3 ↦ 𝑒-target-method-name,
+        i2 ↦ 𝑒-target-class,
+        i3 ↦ 𝑒-target-method,
         i4 ↦ 𝑒-target-signature,
         i5 ↦ Φ̇.false
       ⟧,
@@ -56,8 +56,8 @@ result: |
     ⟧,
     𝜏-invokeinterface ↦ ⟦
       φ ↦ Φ.jeo.opcode.invokeinterface,
-      i2 ↦ 𝑒-stream-class-name,
-      i3 ↦ 𝑒-stream-method-name,
+      i2 ↦ 𝑒-stream-class,
+      i3 ↦ 𝑒-stream-method,
       i4 ↦ 𝑒-stream-signature,
       i5 ↦ Φ̇.true
     ⟧,

--- a/src/test/Foo.java
+++ b/src/test/Foo.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: MIT
  */
 
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.stream.IntStream;
 
 public class Foo {
@@ -11,10 +13,37 @@ public class Foo {
         final int[] input = { 1, 2, 4, 8, 16 };
         final long r = IntStream.of(input)
             .boxed()
+            .map(String::valueOf)
+            .filter(Foo::isNotEmpty)
+            .map(x -> Integer.valueOf(x) + 1)
+            .filter(x -> x > 8)
             .map(x -> x + 1)
-            .map(Integer::doubleValue)
-            .mapToLong(x -> x.longValue())
+            .filter(x -> x > 8)
+            .mapMulti(
+                (BiConsumer<Integer, Consumer<Integer>>) (x, consumer) -> {
+                    if (!bobobo(x)) {
+                        return;
+                    }
+                    consumer.accept(x);
+                }
+            )
+            .mapMulti(
+                (BiConsumer<Integer, Consumer<Integer>>) (x, consumer) -> {
+                    if (bobobo(x)) {
+                        consumer.accept(x);
+                    }
+                }
+            )
+            .mapToLong(x -> (long) x)
             .sum();
         System.out.printf("%d\n", r);
+    }
+
+    private static boolean bobobo(Integer i) {
+        return i > 10;
+    }
+
+    private static boolean isNotEmpty(Object str) {
+        return !((String) str).isEmpty();
     }
 }

--- a/src/test/Foo.java
+++ b/src/test/Foo.java
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: MIT
  */
 
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import java.util.stream.IntStream;
 
 public class Foo {
@@ -13,37 +11,10 @@ public class Foo {
         final int[] input = { 1, 2, 4, 8, 16 };
         final long r = IntStream.of(input)
             .boxed()
-            .map(String::valueOf)
-            .filter(Foo::isNotEmpty)
-            .map(x -> Integer.valueOf(x) + 1)
-            .filter(x -> x > 8)
             .map(x -> x + 1)
-            .filter(x -> x > 8)
-            .mapMulti(
-                (BiConsumer<Integer, Consumer<Integer>>) (x, consumer) -> {
-                    if (!bobobo(x)) {
-                        return;
-                    }
-                    consumer.accept(x);
-                }
-            )
-            .mapMulti(
-                (BiConsumer<Integer, Consumer<Integer>>) (x, consumer) -> {
-                    if (bobobo(x)) {
-                        consumer.accept(x);
-                    }
-                }
-            )
-            .mapToLong(x -> (long) x)
+            .map(Integer::doubleValue)
+            .mapToLong(x -> x.longValue())
             .sum();
         System.out.printf("%d\n", r);
-    }
-
-    private static boolean bobobo(Integer i) {
-        return i > 10;
-    }
-
-    private static boolean isNotEmpty(Object str) {
-        return !((String) str).isEmpty();
     }
 }

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -19,7 +19,7 @@ TESTS=$(subst .phi,,$(subst $(TESTS_DIR)/,,$(TEST_FILES)))
 
 JEO_VERSION=0.12.0
 
-all: test jeo-test run
+all: jeo-test run
 
 run: $(TARGET)/after/Foo.bc diff
 

--- a/src/test/expressions/201-one-lambda-with-filter.phi
+++ b/src/test/expressions/201-one-lambda-with-filter.phi
@@ -35,6 +35,7 @@
           method ↦ "test",
           interface ↦ "()Ljava/util/function/Predicate;",
           lambda-signature ↦ "(Ljava/lang/Object;)Z",
+          target-handle ↦ 6,
           target-class ↦ "Foo",
           target-method ↦ "lambda$main$0",
           target-signature ↦ "(Ljava/lang/Object;)Z",

--- a/src/test/expressions/202-one-lambda-with-map.phi
+++ b/src/test/expressions/202-one-lambda-with-map.phi
@@ -35,6 +35,7 @@
           method ↦ "apply",
           interface ↦ "()Ljava/util/function/Function;",
           lambda-signature ↦ "(Ljava/lang/Object;)Ljava/lang/Object;",
+          target-handle ↦ 6,
           target-class ↦ "Foo",
           target-method ↦ "lambda$main$3",
           target-signature ↦ "(Ljava/lang/String;)Ljava/lang/Integer;",

--- a/src/test/expressions/301-one-filter.phi
+++ b/src/test/expressions/301-one-filter.phi
@@ -32,9 +32,10 @@
         instruction181 ↦ ⟦
           φ ↦ Φ.hone.filter,
           class ↦ "Foo",
+          target-handle ↦ 6,
           target-class ↦ "java/lang/Integer",
           target-method ↦ "valueOf",
-          target-input ↦ "Ljava/lang/Object;",
+          target-signature ↦ "(Ljava/lang/Object;)Z",
           bridge-input ↦ "Ljava/lang/Integer;"
         ⟧
       ⟧,

--- a/src/test/expressions/302-one-map.phi
+++ b/src/test/expressions/302-one-map.phi
@@ -36,10 +36,10 @@
         instruction178 ↦ ⟦
           φ ↦ Φ.hone.map,
           class ↦ "Foo",
+          target-handle ↦ 6,
           target-class ↦ "Foo",
           target-method ↦ "lambda$main$0",
-          target-input ↦ "Ljava/lang/Object;",
-          target-output ↦ "Ljava/lang/Object;",
+          target-signature ↦ "(Ljava/lang/Object;)Ljava/lang/Object;",
           bridge-input ↦ "Ljava/lang/Integer;",
           bridge-output ↦ "Ljava/lang/String;"
         ⟧

--- a/src/test/expressions/402-frame-after-map.phi
+++ b/src/test/expressions/402-frame-after-map.phi
@@ -39,31 +39,32 @@
             consumer ↦ "java/util/function/Consumer"
           ⟧,
           body ↦ ⟦
-            i462 ↦ ⟦
+            i-load ↦ ⟦
+              φ ↦ Φ.jeo.aload,
+              i1 ↦ 0
+            ⟧,
+            i1 ↦ ⟦
               φ ↦ Φ.jeo.opcode.invokestatic,
-              v463 ↦ "java/lang/Integer",
-              v464 ↦ "valueOf",
-              v465 ↦ "(I)Ljava/lang/String;",
-              v466 ↦ Φ̇.false
-            ⟧
-          ⟧
-        ⟧,
-        instruction291 ↦ ⟦
-          φ ↦ Φ.hone.distill,
-          class ↦ "Foo",
-          bridge-input ↦ "Ljava/lang/Integer;",
-          bridge-output ↦ "Ljava/lang/String;",
-          locals ↦ ⟦
-            item ↦ "java/lang/String",
-            consumer ↦ "java/util/function/Consumer"
-          ⟧,
-          body ↦ ⟦
-            i462 ↦ ⟦
-              φ ↦ Φ.jeo.opcode.invokestatic,
-              v463 ↦ "java/lang/Integer",
-              v464 ↦ "valueOf",
-              v465 ↦ "(I)Ljava/lang/Integer;",
-              v466 ↦ Φ̇.false
+              i2 ↦ "Foo",
+              i3 ↦ "lambda$main$2",
+              i4 ↦ "(Ljava/lang/Integer;)Ljava/lang/Integer;",
+              i5 ↦ Φ̇.false
+            ⟧,
+            i-frame ↦ ⟦
+              φ ↦ Φ.jeo.frame,
+              type ↦ 0,
+              nlocal ↦ 6,
+              locals ↦ ⟦
+                φ ↦ Φ.jeo.seq.of,
+                item ↦ "java/lang/Integer",
+                consumer ↦ "java/util/function/Consumer"
+              ⟧,
+              nstack ↦ 2,
+              stack ↦ ⟦
+                φ ↦ Φ.jeo.seq.of2,
+                consumer ↦ "java/util/function/Consumer",
+                item ↦ "java/lang/Integer"
+              ⟧
             ⟧
           ⟧
         ⟧

--- a/src/test/expressions/501-one-distill-to-mapMulti.phi
+++ b/src/test/expressions/501-one-distill-to-mapMulti.phi
@@ -36,9 +36,6 @@
         instruction178 ↦ ⟦
           φ ↦ Φ.hone.distill,
           class ↦ "Foo",
-          target-class ↦ "java/lang/Integer",
-          target-input ↦ "Ljava/lang/Object;",
-          target-output ↦ "Ljava/lang/Object;",
           bridge-input ↦ "Ljava/lang/Integer;",
           bridge-output ↦ "Ljava/lang/String;",
           locals ↦ ⟦

--- a/src/test/expressions/601-one-filter-to-lambda.phi
+++ b/src/test/expressions/601-one-filter-to-lambda.phi
@@ -32,9 +32,10 @@
         instruction181 ↦ ⟦
           φ ↦ Φ.hone.filter,
           class ↦ "Foo",
+          target-handle ↦ 6,
           target-class ↦ "Foo",
           target-method ↦ "lambda$main$0",
-          target-input ↦ "Ljava/lang/Object;",
+          target-signature ↦ "(Ljava/lang/Object;)Z",
           bridge-input ↦ "Ljava/lang/Integer;"
         ⟧
       ⟧,

--- a/src/test/expressions/602-one-map-to-lambda.phi
+++ b/src/test/expressions/602-one-map-to-lambda.phi
@@ -41,10 +41,10 @@
         instruction178 ↦ ⟦
           φ ↦ Φ.hone.map,
           class ↦ "Foo",
+          target-handle ↦ 6,
           target-class ↦ "Foo",
           target-method ↦ "lambda$main$0",
-          target-input ↦ "Ljava/lang/Object;",
-          target-output ↦ "Ljava/lang/Object;",
+          target-signature ↦ "(Ljava/lang/Object;)Ljava/lang/Object;",
           bridge-input ↦ "Ljava/lang/String;",
           bridge-output ↦ "Ljava/lang/Integer;"
         ⟧

--- a/src/test/expressions/603-one-mapMulti-to-lambda.phi
+++ b/src/test/expressions/603-one-mapMulti-to-lambda.phi
@@ -36,9 +36,7 @@
         instruction178 ↦ ⟦
           φ ↦ Φ.hone.mapMulti,
           class ↦ "Foo",
-          target-class ↦ "Foo",
           target-method ↦ "lambda$main$0_bifunc",
-          target-input ↦ "Ljava/lang/Object;",
           bridge-input ↦ "Ljava/lang/Integer;"
         ⟧
       ⟧

--- a/src/test/expressions/701-one-lambda.phi
+++ b/src/test/expressions/701-one-lambda.phi
@@ -35,6 +35,7 @@
           method ↦ "accept",
           interface ↦ "()Ljava/util/function/BiConsumer;",
           lambda-signature ↦ "(Ljava/lang/Object;Ljava/lang/Object;)V",
+          target-handle ↦ 6,
           target-class ↦ "Foo",
           target-method ↦ "lambda$main$2",
           target-signature ↦ "(Ljava/lang/Integer;Ljava/util/function/Consumer;)V",


### PR DESCRIPTION
Ref: #107 

In this PR I did some refactoring + added rule for clearing unnecessary frames after `map`.